### PR TITLE
Tied logger's instance to the correct project

### DIFF
--- a/src/main/java/io/github/vcuswimlab/stackintheflow/controller/Logging.java
+++ b/src/main/java/io/github/vcuswimlab/stackintheflow/controller/Logging.java
@@ -17,16 +17,19 @@ import java.util.UUID;
  */
 public class Logging {
 
-    private Project p;
     private int identifier;
     private PersistSettingsComponent persistSettingsComponent;
 
     // Environment string
     private final static String env = "Production";
 
-    public Logging(){
-        this.p = ProjectManager.getInstance().getOpenProjects()[0];
-        this.identifier = p.getName().hashCode();
+    public Logging() {
+        this.identifier = 0;
+        this.persistSettingsComponent = ServiceManager.getService(PersistSettingsComponent.class);
+    }
+
+    public Logging(Project project){
+        this.identifier = project.getName().hashCode();
         this.persistSettingsComponent = ServiceManager.getService(PersistSettingsComponent.class);
     }
 

--- a/src/main/java/io/github/vcuswimlab/stackintheflow/model/difficulty/DifficultyModel.java
+++ b/src/main/java/io/github/vcuswimlab/stackintheflow/model/difficulty/DifficultyModel.java
@@ -33,7 +33,7 @@ public class DifficultyModel {
     private static final int QUERY_DELAY = 30; // Delay in seconds
     private static final int INACTIVE_DELAY = 15; // Delay in minutes
     private final int MAX_QUEUE_SIZE = 25;
-    private Logging logger = new Logging();
+    private Logging logger;
 
 
     private Project project;
@@ -50,6 +50,7 @@ public class DifficultyModel {
 
     public DifficultyModel(Project project) {
         this.project = project;
+        this.logger = new Logging(project);
         this.persistSettingsComponent = ServiceManager.getService(PersistSettingsComponent.class);
         messageBus = project.getMessageBus();
         connection = messageBus.connect();

--- a/src/main/java/io/github/vcuswimlab/stackintheflow/view/SearchToolWindowGUI.java
+++ b/src/main/java/io/github/vcuswimlab/stackintheflow/view/SearchToolWindowGUI.java
@@ -57,7 +57,7 @@ import java.util.stream.Collectors;
 
 public class SearchToolWindowGUI {
     private JPanel content;
-    private Logging logger = new Logging();
+    private Logging logger;
     private Project project;
 
     private PersonalSearchModel searchModel;
@@ -74,6 +74,7 @@ public class SearchToolWindowGUI {
                                 PersonalSearchModel searchModel) {
         this.content = content;
         this.project = project;
+        this.logger = new Logging(project);
         this.searchModel = searchModel;
         bridge = new JavaBridge(this);
         initComponents();


### PR DESCRIPTION
Logger originally used `ProjectManager.getInstance().getOpenProjects()[0];`.
This was incorrect if more than one project was open.