### PR TITLE
Catch and alert user that no JavaFX was found

### DIFF
--- a/src/main/java/io/github/vcuswimlab/stackintheflow/view/SearchToolWindowFactory.java
+++ b/src/main/java/io/github/vcuswimlab/stackintheflow/view/SearchToolWindowFactory.java
@@ -8,8 +8,16 @@ import io.github.vcuswimlab.stackintheflow.controller.component.stat.tags.UserTa
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import java.awt.*;
 
 public class SearchToolWindowFactory {
+    private static final String NO_JAVAFX_FOUND_MESSAGE =
+            "<html>" +
+                "Your platform does not support JavaFX." +
+                "<br />" +
+                "Please follow the <a href=\"\">instructions</a> to install the dependencies." +
+            "</html>";
+
     private JPanel content;
 
     public SearchToolWindowGUI buildGUI(@NotNull ToolWindow toolWindow, Project project) {
@@ -17,9 +25,24 @@ public class SearchToolWindowFactory {
                 .setContent(content)
                 .setProject(project)
                 .setSearchModel(project.getComponent(UserTagStatComponent.class).getSearchModel()).build();
+
         ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
-        Content windowContent = contentFactory.createContent(windowGUI.getContentPanel(), "", false);
+        Content windowContent;
+
+        // Check if javafx was found
+        if(windowGUI != null) {
+            windowContent = contentFactory.createContent(windowGUI.getContentPanel(), "", false);
+        } else {
+            windowContent = contentFactory.createContent(getNoJavaFXFoundPanel(), "", false);
+        }
+
         toolWindow.getContentManager().addContent(windowContent);
         return windowGUI;
+    }
+
+    private static JPanel getNoJavaFXFoundPanel() {
+        JPanel noJavaFXFoundPanel = new JPanel(new GridBagLayout());
+        noJavaFXFoundPanel.add(new JLabel(NO_JAVAFX_FOUND_MESSAGE));
+        return noJavaFXFoundPanel;
     }
 }

--- a/src/main/java/io/github/vcuswimlab/stackintheflow/view/SearchToolWindowFactory.java
+++ b/src/main/java/io/github/vcuswimlab/stackintheflow/view/SearchToolWindowFactory.java
@@ -1,5 +1,7 @@
 package io.github.vcuswimlab.stackintheflow.view;
 
+import com.intellij.ide.browsers.BrowserLauncher;
+import com.intellij.ide.browsers.WebBrowserManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.content.Content;
@@ -8,6 +10,7 @@ import io.github.vcuswimlab.stackintheflow.controller.component.stat.tags.UserTa
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
 import java.awt.*;
 
 public class SearchToolWindowFactory {
@@ -15,7 +18,7 @@ public class SearchToolWindowFactory {
             "<html>" +
                 "Your platform does not support JavaFX." +
                 "<br />" +
-                "Please follow the <a href=\"\">instructions</a> to install the dependencies." +
+                "Please follow our <a href=\"http://github.com/vcu-swim-lab/stack-intheflow\">instructions</a> to install the dependencies." +
             "</html>";
 
     private JPanel content;
@@ -42,7 +45,17 @@ public class SearchToolWindowFactory {
 
     private static JPanel getNoJavaFXFoundPanel() {
         JPanel noJavaFXFoundPanel = new JPanel(new GridBagLayout());
-        noJavaFXFoundPanel.add(new JLabel(NO_JAVAFX_FOUND_MESSAGE));
+        JEditorPane noJavaFXFoundPane = new JEditorPane();
+        noJavaFXFoundPane.setContentType("text/html");
+        noJavaFXFoundPane.setEditable(false);
+        noJavaFXFoundPane.setOpaque(false);
+        noJavaFXFoundPane.setText(NO_JAVAFX_FOUND_MESSAGE);
+        noJavaFXFoundPane.addHyperlinkListener(e -> {
+            if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+                BrowserLauncher.getInstance().browse(e.getDescription(), WebBrowserManager.getInstance().getFirstActiveBrowser());
+            }
+        });
+        noJavaFXFoundPanel.add(noJavaFXFoundPane);
         return noJavaFXFoundPanel;
     }
 }

--- a/src/main/java/io/github/vcuswimlab/stackintheflow/view/SearchToolWindowGUIBuilder.java
+++ b/src/main/java/io/github/vcuswimlab/stackintheflow/view/SearchToolWindowGUIBuilder.java
@@ -62,6 +62,8 @@ public class SearchToolWindowGUIBuilder {
                     return (SearchToolWindowGUI) searchToolWindowClass.getConstructor(JPanel.class, Project.class, PersonalSearchModel.class).newInstance(content, project, searchModel);
 
                 } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException | InvocationTargetException e) {
+                } catch (NoClassDefFoundError e) {
+                    return null;
                 }
             } else {
                 throw new UnsupportedOperationException("Unable to install JavaFX");


### PR DESCRIPTION
When no builtin JavaFX is found, set tool window to a descriptive message and a link to our github. 